### PR TITLE
Use Lighthouse log rotation configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+    - id: check-yaml
+    - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ansible role that will install, configure and runs [lighthouse](https://lighthou
 
 ### Dependencies
 
-* Docker 
+* Docker
 
 ### Role Variables:
 
@@ -38,6 +38,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `lighthouse_data_dir`            | /opt/lighthouse/data               | Path for data directory                                                                                             |
 | `lighthouse_log_dir`             | /var/log/lighthouse                | Path for logs directory                                                                                             |
 | `lighthouse_log_level`           | "info"                             | Log level                                                                                                           |
+| `lighthouse_log_max_size`        | 25                                 | Log file size in MB to trigger rotation |
+| `lighthouse_log_max_number`      | 14                                 | Number of rotated log files to retain |
 | `lighthouse_network`             | mainnet                            | Predefined network configuration                                                                                    |
 | `lighthouse_jwt_auth_file`       | "/etc/jwt-secret.hex"              | Path of the JWT file                                                                                                |
 | `lighthouse_enable_doppelganger_protection` | True                    | Doppleganger protection enabled by default                                                                          |
@@ -62,7 +64,7 @@ ansible-galaxy install consensys.lighthouse
 ```
 
 Create a requirements.yml with the following:
-Replace `x.y.z` below with the version you would like to use 
+Replace `x.y.z` below with the version you would like to use
 ```
 ---
 - hosts: localhost
@@ -89,7 +91,7 @@ ansible-galaxy install git+https://github.com/consensys/ansible-role-lighthouse.
 ```
 
 Create a requirements.yml with the following:
-Replace `x.y.z` below with the version you would like to use 
+Replace `x.y.z` below with the version you would like to use
 ```
 ---
 - hosts: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,10 @@ lighthouse_validator_cmdline_args: ""
 lighthouse_beacon_custom_cmdline_args: ""
 lighthouse_validator_custom_cmdline_args: ""
 
+# Same configuration used for both beacon and validator services
+lighthouse_log_max_size: 25
+lighthouse_log_max_number: 14
+
 # Managed service config
 lighthouse_systemd_state: restarted
 lighthouse_systemd_dir: /etc/systemd/system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Consensys 
+  author: Consensys
   role_name: lighthouse
   description: lighthouse is an open-source ethereum 2 client
   company: Consensys

--- a/tasks/beacon.yml
+++ b/tasks/beacon.yml
@@ -54,6 +54,13 @@
       --disable-deposit-contract-sync
   when: lighthouse_disable_deposit_contract_sync|bool == True
 
+- name: Add log rotation configuration
+  set_fact:
+    lighthouse_beacon_cmdline_args: >
+      {{lighthouse_beacon_cmdline_args}}
+      --logfile-max-number={{ lighthouse_log_max_number }}
+      --logfile-max-size={{ lighthouse_log_max_size }}
+
 - name: Add custom cli args if provided
   set_fact:
     lighthouse_beacon_cmdline_args: >

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,21 +22,15 @@
     group: "{{ lighthouse_group }}"
   loop:
     - "{{ lighthouse_base_dir }}"
-    - "{{ lighthouse_install_dir }}"    
-    - "{{ lighthouse_config_dir }}"   
+    - "{{ lighthouse_install_dir }}"
+    - "{{ lighthouse_config_dir }}"
     - "{{ lighthouse_keys_dir }}"
-    - "{{ lighthouse_wallet_dir }}"    
-    - "{{ lighthouse_secrets_dir }}" 
+    - "{{ lighthouse_wallet_dir }}"
+    - "{{ lighthouse_secrets_dir }}"
     - "{{ lighthouse_data_dir }}"
     - "{{ lighthouse_data_dir }}"
     - "{{ lighthouse_validator_data_dir }}"
     - "{{ lighthouse_log_dir }}"
-  become: true
-
-- name: Setup logrotate
-  template:
-    src: "logrotate/lighthouse"
-    dest: "/etc/logrotate.d/lighthouse"
   become: true
 
 - name: Extract lighthouse source to install directory

--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -1,12 +1,12 @@
 ---
-- name: Get the default ipv4 address - and set this as the default fallback 
+- name: Get the default ipv4 address - and set this as the default fallback
   set_fact:
     lighthouse_host_ip: >-
       {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if
       hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is
       defined else '127.0.0.1' }}
-    
-- name: Fetch public IP 
+
+- name: Fetch public IP
   uri:
     url: http://ifconfig.me/ip
     method: GET

--- a/tasks/validator.yml
+++ b/tasks/validator.yml
@@ -22,6 +22,13 @@
       --graffiti='{{lighthouse_graffiti}}'
   when: lighthouse_graffiti != ""
 
+- name: Add log rotation configuration
+  set_fact:
+    lighthouse_beacon_cmdline_args: >
+      {{lighthouse_beacon_cmdline_args}}
+      --logfile-max-number={{ lighthouse_log_max_number }}
+      --logfile-max-size={{ lighthouse_log_max_size }}
+
 - name: Add custom cli args if provided
   set_fact:
     lighthouse_validator_cmdline_args: >


### PR DESCRIPTION
Ansible role has been configured to rotate the logs via logrotate. Lighthouse support log rotation in the application so using the native log management. Removed the logrotate configuration from the role as well. Added the pre-commit config and also fixed few format issues identified by the pre-commit