### PR TITLE
Download URL has been changed since lighthouse v5.3.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ lighthouse_user: lighthouse
 lighthouse_group: "{{ lighthouse_user }}"
 lighthouse_architecture: "x86_64"
 # Version to install - linux only!
-lighthouse_download_url: "https://github.com/sigp/lighthouse/releases/download/{{ lighthouse_version }}/lighthouse-{{ lighthouse_version }}-{{lighthouse_architecture}}-unknown-linux-gnu-portable.tar.gz"
+lighthouse_download_url: "https://github.com/sigp/lighthouse/releases/download/{{ lighthouse_version }}/lighthouse-{{ lighthouse_version }}-{{lighthouse_architecture}}-unknown-linux-gnu.tar.gz"
 
 # Directory paths
 lighthouse_base_dir: "/opt/lighthouse"


### PR DESCRIPTION
"-portable" by default, see https://github.com/sigp/lighthouse/releases/tag/v5.3.0