### PR TITLE
Support discovering latest version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,16 @@
 lighthouse_user: lighthouse
 lighthouse_group: "{{ lighthouse_user }}"
 lighthouse_architecture: "x86_64"
+
+# Internal version
+_lighthouse_version: "{{ lighthouse_version }}"
+
 # Version to install - linux only!
-lighthouse_download_url: "https://github.com/sigp/lighthouse/releases/download/{{ lighthouse_version }}/lighthouse-{{ lighthouse_version }}-{{lighthouse_architecture}}-unknown-linux-gnu.tar.gz"
+lighthouse_download_url: "https://github.com/sigp/lighthouse/releases/download/{{ _lighthouse_version }}/lighthouse-{{ _lighthouse_version }}-{{lighthouse_architecture}}-unknown-linux-gnu.tar.gz"
 
 # Directory paths
 lighthouse_base_dir: "/opt/lighthouse"
-lighthouse_install_dir: "{{ lighthouse_base_dir }}/lighthouse-{{ lighthouse_version }}"
+lighthouse_install_dir: "{{ lighthouse_base_dir }}/lighthouse-{{ _lighthouse_version }}"
 lighthouse_current_dir: "{{ lighthouse_base_dir }}/current"
 lighthouse_data_dir: "{{ lighthouse_base_dir }}/data"
 lighthouse_validator_data_dir: "{{ lighthouse_base_dir }}/validatorData"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,7 @@
     - "{{ lighthouse_log_dir }}"
   become: true
 
-- name: Extract lighthouse source to install directory
+- name: Extract lighthouse source to install directory [version {{ _lighthouse_version }}]
   unarchive:
     src: "{{ lighthouse_download_url }}"
     remote_src: true

--- a/tasks/latest.yml
+++ b/tasks/latest.yml
@@ -1,0 +1,20 @@
+- name: Get the latest version from GitHub repository
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/sigp/lighthouse/releases/latest"
+    method: GET
+    status_code: 200
+    return_content: true
+  register: _latest_release_response
+
+- name: Set the version variable
+  ansible.builtin.set_fact:
+    _lighthouse_version: "{{ _latest_release_response.json.tag_name }}"
+
+- name: Validate the discovered lighthouse version
+  ansible.builtin.assert:
+    that: _lighthouse_version is search("^v[0-9]+\.[0-9]+\.[0-9]+$")
+    fail_msg: "Discovered version [{{ _lighthouse_version }}] is not valid"
+
+- name: Information
+  debug:
+    msg: "Latest lighthouse version is {{ _lighthouse_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
         msg: You must set "lighthouse_version" for this role to run
       when: lighthouse_version is not defined
 
+# Retrive latest version when lighthouse_version == 'latest'
+- name: Include task to retrieve latest version
+  ansible.builtin.include_tasks: "latest.yml"
+  when: lighthouse_version == 'latest'
+
 - name: Get IP address to bind to if not provided
   include_tasks: "network.yml"
   when: not lighthouse_host_ip


### PR DESCRIPTION
Ansible role can discover the latest release version when lighthouse_version is set to latest. Introduced variable _lighthouse_version as an internal variable to allow overriding the version. Any value set for role variable such as lighthouse_version via command line cannot be override during the Ansible run