### PR TITLE
Add lighthouse_beacon_environment_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `lighthouse_secrets_dir`    | "/config/secrets"                      |  The secrets directory for validators                                                                                |
 | `lighthouse_beacon_cmdline_args`        | []                         |  List of cli args to append to the internal _lighthouse_beacon_internal_cmdline_args                                  |
 | `lighthouse_validator_cmdline_args`    | []                          |  List of cli args to append to the internal _lighthouse_validator_internal_cmdline_args                               |
+| `lighthouse_beacon_environment_vars`   | []                          |  List of Environment variables to add to the systemd file for lighthouse-beacon, e.g `RUST_LOG=ERROR`                 |
 
 > :warning: **Please do not override _lighthouse_beacon_internal_cmdline_args and _lighthouse_validator_internal_cmdline_args**: Be very careful here! Only use `lighthouse_beacon_cmdline_args` and `lighthouse_validator_cmdline_args` which append to the respective args
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ _lighthouse_validator_internal_cmdline_args: ""
 # these two are lists
 lighthouse_beacon_cmdline_args: []
 lighthouse_validator_cmdline_args: []
+# these end up as systemd Environment entries
+lighthouse_beacon_environment_vars: []
 
 # Same configuration used for both beacon and validator services
 lighthouse_log_max_size: 25

--- a/templates/lighthouse-beacon.service.j2
+++ b/templates/lighthouse-beacon.service.j2
@@ -6,6 +6,11 @@ After=syslog.target network.target
 User={{ lighthouse_user }}
 Group={{ lighthouse_group }}
 Environment=HOME=/home/{{ lighthouse_user }}
+{% if lighthouse_beacon_environment_vars | length > 0 %}
+{% for item in lighthouse_beacon_environment_vars %}
+Environment={{ item }}
+{% endfor %}
+{% endif %}
 Type=simple
 ExecStart=/bin/sh -c "{{ lighthouse_current_dir }}/lighthouse bn {{ _lighthouse_beacon_internal_cmdline_args }}"
 ExecStartPost=/bin/sh -c "/bin/sleep 5 && /bin/chmod 644 {{ lighthouse_log_dir }}/beacon.log"


### PR DESCRIPTION
e.g.
```
lighthouse_beacon_environment_vars:
  - "RUST_LOG=ERROR"
```

Should end up like this in the systemd file

```
Environment=RUST_LOG=ERROR
```